### PR TITLE
Add sequential line numbering to LineItem objects

### DIFF
--- a/SaphetyToDDL.Lib/SaphetyToDDL.cs
+++ b/SaphetyToDDL.Lib/SaphetyToDDL.cs
@@ -318,6 +318,7 @@ namespace SaphetyToDDL.Lib
         /// <returns>The mapped collection of InvoiceLineType objects.</returns>
         private static List<LineItem> MapInvoiceLinesReverse(IEnumerable<Detail> invoiceLines)
         {
+            int currentLineNumber = 1;
             var details = new List<LineItem>();
             foreach (var line in invoiceLines)
             {
@@ -328,6 +329,7 @@ namespace SaphetyToDDL.Lib
                     {
                         Value = (decimal)line.Quantity,
                     },
+                    Number = currentLineNumber++,
                     NetPrice = (decimal)line.UnitPrice,
                     NetLineAmount = (decimal)line.TotalNetAmount,
                     TradeItemIdentification = line.ItemID,


### PR DESCRIPTION
Introduced a `currentLineNumber` variable in the `MapInvoiceLinesReverse` method to assign sequential line numbers to `LineItem` objects. Added a `Number` property to the `LineItem` class, which is populated during iteration over the `invoiceLines` collection.