### PR TITLE
Add TaxableAmount to LineVat and update creation logic

### DIFF
--- a/SaphetyToDDL.Lib/Models/Saphety/LineVat.cs
+++ b/SaphetyToDDL.Lib/Models/Saphety/LineVat.cs
@@ -9,5 +9,8 @@ namespace SaphetyToDDL.Lib.Models.Saphety
 
         [XmlElement("taxTotalValue")]
         public decimal TaxTotalValue { get; set; }
+
+        [XmlElement("taxableAmount")]
+        public decimal TaxableAmount { get; set; }
     }
 }

--- a/SaphetyToDDL.Lib/SaphetyToDDL.cs
+++ b/SaphetyToDDL.Lib/SaphetyToDDL.cs
@@ -341,7 +341,9 @@ namespace SaphetyToDDL.Lib
                 if (line.TaxList.Any() && taxRate.HasValue)
                     detail.LineVat = new LineVat
                     {
-                        TaxPercentage = (decimal)taxRate.Value
+                        TaxPercentage = (decimal)taxRate.Value,
+                        TaxTotalValue = (decimal)(line.TotalTaxAmount.HasValue ? line.TotalTaxAmount.Value : 0),
+                        TaxableAmount = (decimal)line.TotalNetAmount,
                     };
 
 


### PR DESCRIPTION
A new `TaxableAmount` property was added to the `LineVat` class in the `SaphetyToDDL.Lib.Models.Saphety` namespace. It is of type `decimal` and annotated with `[XmlElement("taxableAmount")]` for XML serialization/deserialization.

The logic for creating a `LineVat` object in `SaphetyToDDL.cs` was updated. The `TaxTotalValue` property is now explicitly set to `line.TotalTaxAmount` or `0` if it doesn't exist. The new `TaxableAmount` property is set to `line.TotalNetAmount`.